### PR TITLE
Add note about minishift issue

### DIFF
--- a/content/quickstarts/virtualization/setup.md
+++ b/content/quickstarts/virtualization/setup.md
@@ -46,3 +46,5 @@ The beetle-studio services provide the UI, API and repository for generating new
   </video>
   <div id="caption">Video installing beetle-studio</div>
 </div>
+
+**NOTE:** if you are using minishift 1.18, you should install **admin-user** addon to the minishift (*minishift addon apply admin-user*) and login as admin instead of system:admin due to this issue https://github.com/minishift/minishift/issues/2107


### PR DESCRIPTION
Today, I went through virtualization/setup quickstart. I was not able to login into minishift as system:admin. After login, minishift showed error: username system:admin is invalid for basic auth.
I have found that current minishift has this issue https://github.com/minishift/minishift/issues/2107 .

The solution according to this comment https://github.com/minishift/minishift/issues/2107#issuecomment-394042980 is to use *admin-user* addon and login to the minishift as admin.

So I have added the note to the website with this issue.